### PR TITLE
Archive issue #5 - Logstash Auth

### DIFF
--- a/pipeline/02-pscheduler_common.conf
+++ b/pipeline/02-pscheduler_common.conf
@@ -6,6 +6,12 @@
 #           NOTE: fingerprint filter can't handle nested objects
 
 filter {
+    if [message] {
+        ruby {
+            path => "/usr/lib/perfsonar/logstash/ruby/pscheduler_proxy_normalize.rb"
+        }
+    }
+
     mutate {
         remove_field => [ "schedule" ]
     }

--- a/ruby/pscheduler_proxy_normalize.rb
+++ b/ruby/pscheduler_proxy_normalize.rb
@@ -1,0 +1,13 @@
+require 'json'
+
+def filter(event)
+    message = event.get("[message]")
+    event.remove("[message]")
+
+    original_event = JSON.parse(message)
+    original_event.each do |fieldname, value|
+        event.set(fieldname, value)
+    end
+    
+    return [event]
+end


### PR DESCRIPTION
This PR adds a ruby script to the logstash pipeline to handle the event changes that happen when the task results are sent through the reverse proxy. It's necessary to use the logstash auth, please revise it Andy and Daniel.