### PR TITLE
Updating names of logstash pipeline variables from elastic to opensearch

### DIFF
--- a/pipeline/99-outputs.conf
+++ b/pipeline/99-outputs.conf
@@ -1,14 +1,12 @@
 output {
     #If has [test][type] create index using that in name.
-    # Also creates index template on logstash startup
     if [test][type] {
         opensearch {
-            hosts => ["${elastic_output_host}"]
+            hosts => ["${opensearch_output_host}"]
             ssl_certificate_verification => false
-            user => "${elastic_output_user}"
-            password => "${elastic_output_password}"
+            user => "${opensearch_output_user}"
+            password => "${opensearch_output_password}"
             index => "pscheduler_%{[test][type]}-%{+YYYY.MM.dd}"
-     
         }
     }
 }

--- a/pipeline_etc/logstash_sysconfig
+++ b/pipeline_etc/logstash_sysconfig
@@ -1,6 +1,6 @@
 ## Logstash environment variables.
 log_level=info
-elastic_output_host=https://localhost:9200/
-elastic_output_user=pscheduler_logstash
-elastic_output_password=pscheduler_logstash
+opensearch_output_host=https://localhost:9200
+opensearch_output_user=pscheduler_logstash
+opensearch_output_password=pscheduler_logstash
 XPACK_MONITORING_ENABLED=False


### PR DESCRIPTION
These are just some changes to reflect the new naming conventions of elastic->opensearch