### PR TITLE
Added recording of missing responses, i.e. *s

### DIFF
--- a/perfsonar-logstash/perfsonar-logstash/ruby/pscheduler_trace.rb
+++ b/perfsonar-logstash/perfsonar-logstash/ruby/pscheduler_trace.rb
@@ -1,5 +1,6 @@
 def filter(event)
     paths = event.get("[result][paths]")
+    ip_version = event.get("[test][spec][ip-version]")
     if paths and paths.respond_to?('length') and paths.length() > 0 then
         #only look at first path for now, multipath is not this use case 
         hop_ips = []
@@ -14,8 +15,15 @@ def filter(event)
                 hop_ips.push(hop["ip"])
                 success_count += 1
             else
+                # Add zero (non-global) address to indicate missing info for hop
+                if ip_version == 4
+                  hop_ips.push("0.0.0.0")
+                end  
+                if ip_version == 6
+                    hop_ips.push("::")
+                end                  
                 error_count += 1
-                next
+                #next
             end
             
             #ASN
@@ -27,6 +35,11 @@ def filter(event)
                 if hop["as"]["owner"] then
                     hop_asos.push(hop["as"]["owner"])
                 end
+            else
+              # Add zero number (non-valid) number to indicate missing info for hop
+              hop_asns.push(0)
+              # Add "not-available" to indicate missing info for hop
+              hop_asos.push("n/a")
             end
             
             #Path MTU
@@ -44,9 +57,11 @@ def filter(event)
         event.set("[@metadata][result][hop][success_count]", success_count)
         event.set("[@metadata][result][hop][error_count]", error_count)
         event.set("[@metadata][result][hop][ip]", hop_ips)
-        event.set("[@metadata][result][hop][ip_str]", hop_ips.join(" "))
+        # Apply traditional * for missing hop
+        event.set("[@metadata][result][hop][ip_str]", hop_ips.join(" ").gsub(/^0.0.0.0 /, "* ").gsub(/ 0.0.0.0 /, " * ").gsub(/ 0.0.0.0$/," *").gsub(/^:: /, "* ").gsub(/ :: /, " * ").gsub(/ ::$/," *"))
         event.set("[@metadata][result][hop][as_number]", hop_asns)
-        event.set("[@metadata][result][hop][as_number_str]", hop_asns.join(" "))
+        # Apply traditional * for missing hop
+        event.set("[@metadata][result][hop][as_number_str]", hop_asns.join(" ").gsub(/^0 /, "* ").gsub(/ 0 /, " * ").gsub(/ 0$/," *")) 
         event.set("[@metadata][result][hop][as_organization]", hop_asos)
         event.set("[@metadata][result][hop][as_organization_str]", hop_asos.join(" "))
         if path_mtu then


### PR DESCRIPTION
Ref issue https://github.com/perfsonar/grafana/issues/42

Code has been added which adds "null" into lists of traceroute results where a TTL response i missing.
  - \* is added in strings.
  - 0.0.0.0 or :: is added in ipv4 and ipv6 address lists respectively.
  - 0 and "n/a" is added in ASN number and name lists respectively. 